### PR TITLE
update bench

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,34 +13,40 @@ mix run run.ex
 
 From my personal computer, the result is
 ```
-Elixir 1.3.0
+Erlang/OTP 18 [erts-7.3] [source] [64-bit] [smp:4:4] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]
+Elixir 1.3.1
 Benchmark suite executing with the following configuration:
 warmup: 2.0s
 time: 5.0s
 parallel: 1
-Estimated total run time: 35.0s
+Estimated total run time: 42.0s
 
 Benchmarking binary_comprehension_test...
 Benchmarking binary_loop_test...
 Benchmarking list_comprehension_test...
 Benchmarking list_iter_test...
-Benchmarking list_loop_test...
+Benchmarking list_loop_with_iodata_to_binary_test...
+Warning: The function you are trying to benchmark is super fast, making measures more unreliable! See: https://github.com/PragTob/benchee/wiki/Benchee-Warnings#fast-execution-warning
+
+Benchmarking list_loop_with_list_to_binary_test...
 Warning: The function you are trying to benchmark is super fast, making measures more unreliable! See: https://github.com/PragTob/benchee/wiki/Benchee-Warnings#fast-execution-warning
 
 
-Name                                ips        average  deviation         median
-list_loop_test                 124.38 K        8.04 μs    ±28.69%        7.00 μs
-binary_loop_test               108.31 K        9.23 μs    ±80.18%        8.00 μs
-list_comprehension_test         97.55 K       10.25 μs   ±127.25%        9.00 μs
-list_iter_test                  94.39 K       10.59 μs   ±109.99%        9.00 μs
-binary_comprehension_test       77.62 K       12.88 μs    ±92.25%       10.00 μs
+Name                                           ips        average  deviation         median
+list_loop_with_list_to_binary_test        133.56 K        7.49 μs    ±26.22%        6.90 μs
+list_loop_with_iodata_to_binary_test      132.40 K        7.55 μs    ±38.54%        6.90 μs
+binary_loop_test                          110.02 K        9.09 μs   ±162.35%        8.00 μs
+list_comprehension_test                   106.60 K        9.38 μs    ±62.35%        9.00 μs
+list_iter_test                             99.28 K       10.07 μs   ±101.25%        9.00 μs
+binary_comprehension_test                  98.06 K       10.20 μs   ±179.18%        9.00 μs
 
 Comparison:
-list_loop_test                 124.38 K
-binary_loop_test               108.31 K - 1.15x slower
-list_comprehension_test         97.55 K - 1.28x slower
-list_iter_test                  94.39 K - 1.32x slower
-binary_comprehension_test       77.62 K - 1.60x slower
+list_loop_with_list_to_binary_test        133.56 K
+list_loop_with_iodata_to_binary_test      132.40 K - 1.01x slower
+binary_loop_test                          110.02 K - 1.21x slower
+list_comprehension_test                   106.60 K - 1.25x slower
+list_iter_test                             99.28 K - 1.35x slower
+binary_comprehension_test                  98.06 K - 1.36x slower
 ```
 
-The best solution would be `list_loop_test`
+The best solution would be `list_loop_with_list_to_binary_test`

--- a/lib/bench.ex
+++ b/lib/bench.ex
@@ -1,7 +1,10 @@
 defmodule Bench do
 
-  def list_loop_test(n) do
+  def list_loop_with_iodata_to_binary_test(n) do
     do_list_loop(n, [])
+  end
+  def list_loop_with_list_to_binary_test(n) do
+    do_list_loop_2(n, [])
   end
 
   def list_iter_test(n) do
@@ -23,13 +26,19 @@ defmodule Bench do
   defp do_binary_loop(0, acc), do: acc
   defp do_binary_loop(n, acc) do
     random = Enum.random(?a..?z)
-    do_binary_loop(n - 1, << acc::binary, random>>)
+    do_binary_loop(n - 1, << random, acc::binary>>)
   end
 
   defp do_list_loop(0, acc), do: acc |> IO.iodata_to_binary
   defp do_list_loop(size, acc) do
       random = Enum.random(?a..?z)
       do_list_loop(size - 1, [random|acc])
+  end
+
+  defp do_list_loop_2(0, acc), do: acc |> :erlang.list_to_binary
+  defp do_list_loop_2(size, acc) do
+    random = Enum.random(?a..?z)
+    do_list_loop_2(size - 1, [random|acc])
   end
 
   def do_list_iter(n) when n > 0, do: Enum.map(1..n, fn _ -> Enum.random(?a..?z) end) |> IO. iodata_to_binary
@@ -45,3 +54,4 @@ defmodule Bench do
   end
   def do_binary_comprehension(_), do: ""
 end
+

--- a/run.ex
+++ b/run.ex
@@ -1,12 +1,13 @@
 defmodule Main do
   def run(count) do
     Benchee.run(%{}, %{
-      "list_loop_test" => fn -> Bench.list_loop_test(count) end,
-      "list_iter_test" => fn -> Bench.list_iter_test(count) end,
-      "list_comprehension_test" => fn -> Bench.list_comprehension_test(count) end,
-      "binary_comprehension_test" => fn -> Bench.binary_comprehension_test(count) end,
-      "binary_loop_test" => fn -> Bench.binary_loop_test(count) end
-    })
+          "binary_loop_test" => fn -> Bench.binary_loop_test(count) end,
+          "list_loop_with_iodata_to_binary_test" => fn -> Bench.list_loop_with_iodata_to_binary_test(count) end,
+          "list_loop_with_list_to_binary_test" => fn -> Bench.list_loop_with_list_to_binary_test(count) end,
+          "list_iter_test" => fn -> Bench.list_iter_test(count) end,
+          "list_comprehension_test" => fn -> Bench.list_comprehension_test(count) end,
+          "binary_comprehension_test" => fn -> Bench.binary_comprehension_test(count) end,
+                })
   end
 end
 


### PR DESCRIPTION
Update:
1. Using `list_to_binary/1` replace `io:iodata_to_binary/1`, because we already known it's a list.
2. Update `<< random, acc::binary>>` replace `<< acc::binary, random>>`, make sure benchmark more fair.

Great to know!!
`[item|list]` is faster than `<<item, list/binary>>`
But binary construction is more flexible then list construction
we can do 
```ex
item = 100,
list = <<1,2,,3,4,5,6>>
<<Item, list/binary>> # add item at head
or 
<<list/binary, item>> # add item at tail
```
if it a list, we only can do
```ex
[item|list] # add item at head, can't add it to tail.
```



